### PR TITLE
solved gflags import problem

### DIFF
--- a/preprocess/parse_replay_info.py
+++ b/preprocess/parse_replay_info.py
@@ -9,7 +9,7 @@ import json
 import signal
 import threading
 import queue as Queue
-import gflags as flags
+from absl import flags
 import multiprocessing
 from itertools import chain
 from future.builtins import range


### PR DESCRIPTION
gflags are not supported any more 
import gflags as flags
better to use absl instad 

https://github.com/chris-chris/pysc2-examples/issues/5#issuecomment-337370481