### PR TITLE
Fixed URL with bad markdown formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 }
 ```
 ## Download
-- **Global** features are available [HERE]([https://drive.google.com/open?id=0Bybnpq8dvwudNUVOX1FCWnZoSGM](https://drive.google.com/file/d/0Bybnpq8dvwudNUVOX1FCWnZoSGM/view?usp=sharing&resourcekey=0-GJ3Loydd4k2QaONnVd3B5Q)).
+- **Global** features are available [HERE](https://drive.google.com/file/d/0Bybnpq8dvwudNUVOX1FCWnZoSGM/view?usp=sharing&resourcekey=0-GJ3Loydd4k2QaONnVd3B5Q).
 - **[TRAIN|VAL|TEST]** split is available [HERE](train_val_test).
 - **[Stat]** is available [HERE](parsed_replays/Stat). The stat files with postfix **_human.json** are human-readable.
 - **Spatial** features are **NOT** avaiable since I do not have any download server. Please follow the [instructions](#step-by-step-instructions) to generate the spatial features by yourself.


### PR DESCRIPTION
The latest change which introduced a working link broke Markdown syntax.
It is now fixed

I am sorry for this mistake. I have verified the code and all should work now.